### PR TITLE
feat: P3 内存MMR重排序+时间衰减 & SecretRef配置安全

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -436,6 +436,11 @@ func Load(path string) (*Config, error) {
 	// Apply any pending schema migrations and persist if changed
 	applyMigrations(&cfg, path)
 
+	// Resolve SecretRef values (e.g. {"$env": "ANTHROPIC_API_KEY"})
+	if err := ResolveSecretRefs(&cfg); err != nil {
+		return nil, fmt.Errorf("config secret resolution: %w", err)
+	}
+
 	return &cfg, nil
 }
 

--- a/pkg/config/secretref.go
+++ b/pkg/config/secretref.go
@@ -1,0 +1,133 @@
+// pkg/config/secretref.go — SecretRef: runtime secret resolution for config values.
+//
+// # Overview
+//
+// Instead of storing sensitive values (API keys, bot tokens, passwords) as
+// plain strings in aipanel.json, you can reference them via SecretRef objects:
+//
+//	Environment variable:
+//	  "apiKey": {"$env": "ANTHROPIC_API_KEY"}
+//
+//	File contents:
+//	  "botToken": {"$file": "/run/secrets/telegram_token"}
+//
+// Plain string values are passed through unchanged (backward-compatible).
+//
+// # Usage
+//
+// Call ResolveSecretRefs(cfg) after loading a Config from disk.
+// It walks all known string fields and resolves any SecretRef it finds.
+//
+// To resolve a single value (e.g. inside custom code):
+//
+//	plain, err := ResolveValue(`{"$env": "MY_VAR"}`)
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// secretRef is the wire format for a secret reference.
+// Exactly one of Env or File should be non-empty.
+type secretRef struct {
+	Env  string `json:"$env,omitempty"`
+	File string `json:"$file,omitempty"`
+}
+
+// ResolveValue parses a JSON string value that may contain a SecretRef.
+//
+// Behaviour:
+//   - If value is a JSON object with "$env" key → read from environment variable.
+//   - If value is a JSON object with "$file" key → read from file (trimmed).
+//   - Otherwise → return value unchanged.
+//
+// Returns an error if the referenced env var is unset or the file cannot be read.
+func ResolveValue(value string) (string, error) {
+	v := strings.TrimSpace(value)
+	if !strings.HasPrefix(v, "{") {
+		return value, nil // plain string — pass through
+	}
+
+	var ref secretRef
+	if err := json.Unmarshal([]byte(v), &ref); err != nil {
+		return value, nil // not a valid JSON object — treat as plain string
+	}
+
+	switch {
+	case ref.Env != "":
+		env := os.Getenv(ref.Env)
+		if env == "" {
+			return "", fmt.Errorf("secretref: environment variable %q is not set", ref.Env)
+		}
+		return env, nil
+
+	case ref.File != "":
+		data, err := os.ReadFile(ref.File)
+		if err != nil {
+			return "", fmt.Errorf("secretref: cannot read file %q: %w", ref.File, err)
+		}
+		return strings.TrimRight(string(data), "\n\r"), nil
+
+	default:
+		return value, nil // unknown SecretRef format — pass through
+	}
+}
+
+// ResolveSecretRefs resolves all SecretRef values embedded in cfg.
+//
+// It walks every known string-typed credential field across the Config
+// and replaces SecretRef JSON objects with the resolved plaintext value.
+// Fields without a SecretRef are left unchanged.
+//
+// Returns the first resolution error encountered, or nil on success.
+func ResolveSecretRefs(cfg *Config) error {
+	// ── ProviderEntry.APIKey ─────────────────────────────────────────────────
+	for i := range cfg.Providers {
+		v, err := ResolveValue(cfg.Providers[i].APIKey)
+		if err != nil {
+			return fmt.Errorf("providers[%s].apiKey: %w", cfg.Providers[i].ID, err)
+		}
+		cfg.Providers[i].APIKey = v
+	}
+
+	// ── ModelEntry.APIKey (legacy / per-model key) ───────────────────────────
+	for i := range cfg.Models {
+		v, err := ResolveValue(cfg.Models[i].APIKey)
+		if err != nil {
+			return fmt.Errorf("models[%s].apiKey: %w", cfg.Models[i].ID, err)
+		}
+		cfg.Models[i].APIKey = v
+	}
+
+	// ── ToolEntry.APIKey ─────────────────────────────────────────────────────
+	for i := range cfg.Tools {
+		v, err := ResolveValue(cfg.Tools[i].APIKey)
+		if err != nil {
+			return fmt.Errorf("tools[%s].apiKey: %w", cfg.Tools[i].ID, err)
+		}
+		cfg.Tools[i].APIKey = v
+	}
+
+	// ── ChannelEntry.Config (map[string]string) ──────────────────────────────
+	for i := range cfg.Channels {
+		for k, val := range cfg.Channels[i].Config {
+			v, err := ResolveValue(val)
+			if err != nil {
+				return fmt.Errorf("channels[%s].config[%s]: %w", cfg.Channels[i].ID, k, err)
+			}
+			cfg.Channels[i].Config[k] = v
+		}
+	}
+
+	// ── AuthConfig.Token ─────────────────────────────────────────────────────
+	v, err := ResolveValue(cfg.Auth.Token)
+	if err != nil {
+		return fmt.Errorf("auth.token: %w", err)
+	}
+	cfg.Auth.Token = v
+
+	return nil
+}

--- a/pkg/memory/indexer.go
+++ b/pkg/memory/indexer.go
@@ -104,7 +104,12 @@ func chunkAllFiles(memTree *MemoryTree) ([]Chunk, error) {
 		if err != nil {
 			return nil // best-effort
 		}
-		chunks = append(chunks, splitIntoChunks(string(data), rel)...)
+		fileChunks := splitIntoChunks(string(data), rel)
+		// Stamp each chunk with the file's modification time for temporal decay.
+		for i := range fileChunks {
+			fileChunks[i].CreatedAt = info.ModTime()
+		}
+		chunks = append(chunks, fileChunks...)
 		return nil
 	})
 	return chunks, err

--- a/pkg/memory/mmr.go
+++ b/pkg/memory/mmr.go
@@ -1,0 +1,162 @@
+// pkg/memory/mmr.go — Maximal Marginal Relevance re-ranking + temporal decay.
+//
+// MMR improves memory search diversity by penalizing results that are too
+// similar to already-selected results, while still preferring results that
+// are relevant to the original query.
+//
+// Usage:
+//
+//	candidates := idx.retrieveCandidates(queryVec, query, topK*3)
+//	candidates = ApplyTemporalDecay(candidates, 30)
+//	results := MMR(queryVec, candidates, 0.7, topK)
+package memory
+
+import (
+	"math"
+	"time"
+)
+
+// DefaultMMRLambda is the default trade-off parameter λ for MMR.
+// Higher λ (e.g. 0.7) favours relevance; lower λ (e.g. 0.3) favours diversity.
+const DefaultMMRLambda = 0.7
+
+// DefaultHalfLifeDays is the default temporal decay half-life in days.
+// After this many days the score is halved.
+const DefaultHalfLifeDays = 30.0
+
+// MMR selects up to topK results from candidates using Maximal Marginal Relevance.
+//
+// Score formula:
+//
+//	mmr(d) = λ * sim(query, d) - (1-λ) * max_{d_s ∈ selected} sim(d, d_s)
+//
+// where sim is cosine similarity when vectors are available, or score-based
+// similarity otherwise.
+//
+// Parameters:
+//   - query:      query embedding vector (may be nil → fall back to score-only mode)
+//   - candidates: scored candidate results (already retrieved + decay applied)
+//   - lambda:     trade-off λ ∈ [0,1]; use DefaultMMRLambda if unsure
+//   - topK:       number of results to return
+func MMR(query []float32, candidates []SearchResult, lambda float64, topK int) []SearchResult {
+	if len(candidates) == 0 {
+		return nil
+	}
+	if topK <= 0 {
+		topK = 5
+	}
+	if topK > len(candidates) {
+		topK = len(candidates)
+	}
+	if lambda < 0 {
+		lambda = 0
+	}
+	if lambda > 1 {
+		lambda = 1
+	}
+
+	// Track which candidates have been selected (by index)
+	selected := make([]SearchResult, 0, topK)
+	remaining := make([]int, len(candidates))
+	for i := range remaining {
+		remaining[i] = i
+	}
+
+	// Normalise scores to [0,1] for consistent MMR computation when
+	// no query vector is available.
+	maxScore := 0.0
+	for _, c := range candidates {
+		if c.Score > maxScore {
+			maxScore = c.Score
+		}
+	}
+	if maxScore == 0 {
+		maxScore = 1
+	}
+
+	for len(selected) < topK && len(remaining) > 0 {
+		bestIdx := -1
+		bestMMR := math.Inf(-1)
+
+		for _, ri := range remaining {
+			c := candidates[ri]
+
+			// Relevance: cosine(query, d) if we have vectors; else normalised score
+			var relevance float64
+			if query != nil && len(c.Vec) > 0 {
+				relevance = cosineSim(query, c.Vec)
+			} else {
+				relevance = c.Score / maxScore
+			}
+
+			// Diversity penalty: max cosine similarity to already-selected items
+			maxSim := 0.0
+			for _, s := range selected {
+				var sim float64
+				if len(c.Vec) > 0 && len(s.Vec) > 0 {
+					sim = cosineSim(c.Vec, s.Vec)
+				} else {
+					// Approximate similarity by score proximity
+					diff := math.Abs(c.Score-s.Score) / maxScore
+					sim = 1 - diff
+				}
+				if sim > maxSim {
+					maxSim = sim
+				}
+			}
+
+			mmrScore := lambda*relevance - (1-lambda)*maxSim
+			if mmrScore > bestMMR {
+				bestMMR = mmrScore
+				bestIdx = ri
+			}
+		}
+
+		if bestIdx < 0 {
+			break
+		}
+
+		// Move bestIdx from remaining to selected
+		selected = append(selected, candidates[bestIdx])
+		newRemaining := make([]int, 0, len(remaining)-1)
+		for _, ri := range remaining {
+			if ri != bestIdx {
+				newRemaining = append(newRemaining, ri)
+			}
+		}
+		remaining = newRemaining
+	}
+
+	return selected
+}
+
+// ApplyTemporalDecay adjusts each result's Score by an exponential decay factor
+// based on the age of the source document:
+//
+//	score *= exp(-ln(2) * age_days / halfLifeDays)
+//
+// This means after halfLifeDays days the score is halved.
+// Results whose CreatedAt is zero (unknown time) are left unchanged.
+//
+// Parameters:
+//   - results:      list of SearchResult to adjust (modified in-place and returned)
+//   - halfLifeDays: decay half-life in days; use DefaultHalfLifeDays (30) if unsure
+func ApplyTemporalDecay(results []SearchResult, halfLifeDays float64) []SearchResult {
+	if halfLifeDays <= 0 {
+		halfLifeDays = DefaultHalfLifeDays
+	}
+	now := time.Now()
+	for i := range results {
+		if results[i].CreatedAt.IsZero() {
+			continue // no time information — skip decay
+		}
+		ageDays := now.Sub(results[i].CreatedAt).Hours() / 24
+		if ageDays < 0 {
+			ageDays = 0
+		}
+		// exp(-ln(2) * age / halfLife) = 0.5 when age == halfLife
+		decay := math.Exp(-math.Ln2 * ageDays / halfLifeDays)
+		results[i].Score *= decay
+	}
+	return results
+}

--- a/pkg/memory/search.go
+++ b/pkg/memory/search.go
@@ -15,10 +15,18 @@ const searchIndexFile = ".search_index.gob"
 
 // Chunk is a single indexed memory fragment.
 type Chunk struct {
-	Text   string    // 段落原文
-	Source string    // 相对于 workspace 的路径，如 "memory/core/knowledge.md"
-	Line   int       // 在源文件中的起始行号（1-indexed）
-	Vec    []float32 // embedding 向量；nil = 仅 BM25 模式
+	Text      string    // 段落原文
+	Source    string    // 相对于 workspace 的路径，如 "memory/core/knowledge.md"
+	Line      int       // 在源文件中的起始行号（1-indexed）
+	Vec       []float32 // embedding 向量；nil = 仅 BM25 模式
+	CreatedAt time.Time // 来源文件的修改时间；零值表示未知
+}
+
+// SearchResult wraps a Chunk with its retrieval score and timestamp,
+// used for MMR re-ranking and temporal decay.
+type SearchResult struct {
+	Chunk
+	Score float64 // 原始检索分数（cosine 相似度或 BM25 分）
 }
 
 // SearchIndex holds all indexed chunks for one agent workspace.
@@ -100,6 +108,11 @@ func (m *MemoryTree) anyNewerThan(dir string, t time.Time) bool {
 
 // Search returns the top-K most relevant chunks for the given query.
 //
+// Pipeline:
+//  1. Retrieve topK*3 candidates via cosine similarity (if vectors available) or BM25.
+//  2. Apply temporal decay (score *= exp(-ln2 * age_days / halfLifeDays)).
+//  3. MMR re-ranking to reduce redundancy and improve diversity.
+//
 // If chunks have Vec and queryVec is non-nil → cosine similarity.
 // Otherwise → BM25 keyword scoring (Chinese + English both supported).
 func (idx *SearchIndex) Search(queryVec []float32, query string, topK int) []Chunk {
@@ -110,10 +123,28 @@ func (idx *SearchIndex) Search(queryVec []float32, query string, topK int) []Chu
 		topK = 5
 	}
 
-	type scored struct {
-		chunk Chunk
-		score float64
+	// Step 1: retrieve topK*3 candidates
+	candidates := idx.retrieveCandidates(queryVec, query, topK*3)
+	if len(candidates) == 0 {
+		return nil
 	}
+
+	// Step 2: temporal decay
+	candidates = ApplyTemporalDecay(candidates, 30)
+
+	// Step 3: MMR re-ranking
+	reranked := MMR(queryVec, candidates, 0.7, topK)
+
+	result := make([]Chunk, 0, len(reranked))
+	for _, r := range reranked {
+		result = append(result, r.Chunk)
+	}
+	return result
+}
+
+// retrieveCandidates returns up to candidateK scored results using cosine/BM25.
+func (idx *SearchIndex) retrieveCandidates(queryVec []float32, query string, candidateK int) []SearchResult {
+	type scored = SearchResult
 
 	// Decide mode: use vectors if available
 	hasVec := len(idx.Chunks) > 0 && len(idx.Chunks[0].Vec) > 0
@@ -132,8 +163,12 @@ func (idx *SearchIndex) Search(queryVec []float32, query string, topK int) []Chu
 		// ── BM25 keyword scoring ─────────────────────────────────────────
 		terms := tokenize(query)
 		if len(terms) == 0 {
-			n := min(topK, len(idx.Chunks))
-			return idx.Chunks[:n]
+			n := min(candidateK, len(idx.Chunks))
+			out := make([]SearchResult, n)
+			for i := 0; i < n; i++ {
+				out[i] = SearchResult{idx.Chunks[i], 1.0}
+			}
+			return out
 		}
 
 		N := float64(len(idx.Chunks))
@@ -179,13 +214,12 @@ func (idx *SearchIndex) Search(queryVec []float32, query string, topK int) []Chu
 		}
 	}
 
-	sort.Slice(scores, func(i, j int) bool { return scores[i].score > scores[j].score })
+	sort.Slice(scores, func(i, j int) bool { return scores[i].Score > scores[j].Score })
 
-	result := make([]Chunk, 0, topK)
-	for i := 0; i < topK && i < len(scores); i++ {
-		result = append(result, scores[i].chunk)
+	if candidateK < len(scores) {
+		scores = scores[:candidateK]
 	}
-	return result
+	return scores
 }
 
 // ── Math helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## P3 功能

### 内存检索增强
- MMR重排序：λ=0.7，在相关性和多样性之间权衡，消除冗余结果
- 时间衰减：exp(-ln2*age/halfLife)，半衰期30天，新内容权重更高
- 检索流程：候选召回(topK*3) → 时间衰减 → MMR重排 → 返回topK

### SecretRef 配置安全
- 支持 {"$env": "VAR_NAME"} 从环境变量读取敏感值
- 支持 {"$file": "/path"} 从文件读取敏感值
- 配置加载时自动递归解析，明文值保持兼容