### PR TITLE
fix: loadSession 过滤空消息（彻底修复空白气泡）

### DIFF
--- a/ui/src/components/AiChat.vue
+++ b/ui/src/components/AiChat.vue
@@ -1396,6 +1396,7 @@ async function resumeSession(sessionId: string) {
     }
     for (const m of parsed) {
       if (m.role === 'compaction') continue  // skip raw compaction entries
+      if (!m.text?.trim() && !(m.toolCalls?.length)) continue  // skip empty messages
       loaded.push({
         role: m.role as 'user' | 'assistant',
         text: m.text,


### PR DESCRIPTION
上一版漏了 loadSession 函数里的 loaded.push，这里也加上空消息过滤。