### PR TITLE
feat: Coordinator模式 + SessionMemory + AgentDefinition标准化（借鉴CC源码）

### DIFF
--- a/cmd/aipanel/main.go
+++ b/cmd/aipanel/main.go
@@ -170,7 +170,7 @@ func main() {
 
 	// Wire up completion notify: when a background task finishes, inject a message
 	// into the parent session so the user sees the result on next open.
-	subagentMgr.SetNotify(func(spawnedBy, spawnedBySession, taskID, label, output string, status subagent.TaskStatus) {
+	subagentMgr.SetNotify(func(spawnedBy, spawnedBySession, taskID, label, output, notifXML string, status subagent.TaskStatus) {
 		if spawnedBy == "" || spawnedBySession == "" {
 			return
 		}
@@ -179,6 +179,16 @@ func main() {
 			return
 		}
 		store := session.NewStore(ag.SessionDir)
+
+		// Inject <task-notification> XML as a user-role message into the parent session.
+		// This follows the Coordinator pattern: the XML block is delivered as a
+		// "user" message so the Coordinator agent sees it on its next turn and can
+		// continue or spawn follow-up workers accordingly.
+		//
+		// Format: <task-notification>...</task-notification> (see subagent/coordinator.go)
+		//
+		// Legacy fallback: also append a human-readable assistant message so the UI
+		// shows the result even if the agent hasn't processed the XML yet.
 		var statusIcon string
 		switch status {
 		case subagent.TaskDone:
@@ -194,10 +204,18 @@ func main() {
 		if taskLabel == "" {
 			taskLabel = taskID
 		}
+
+		// 1. Inject XML notification as "user" message (for Coordinator to process)
+		if notifXML != "" {
+			xmlContent, _ := json.Marshal(notifXML)
+			_ = store.AppendMessage(spawnedBySession, "user", xmlContent)
+		}
+
+		// 2. Append human-readable summary as "assistant" for UI display
 		msg := fmt.Sprintf("[后台任务完成] %s **%s**（任务 ID: %s）\n\n%s", statusIcon, taskLabel, taskID, output)
 		content, _ := json.Marshal(msg)
-		// Save as "assistant" so it renders on the left side (not as a user bubble)
 		_ = store.AppendMessage(spawnedBySession, "assistant", content)
+
 		log.Printf("[subagent] notify: task %s (%s) → session %s", taskID, status, spawnedBySession)
 	})
 

--- a/pkg/agent/definition.go
+++ b/pkg/agent/definition.go
@@ -1,0 +1,178 @@
+// Package agent — AgentDefinition: unified agent definition structure.
+// Inspired by Claude Code's tools/AgentTool/loadAgentsDir.ts AgentDefinition type.
+package agent
+
+// AgentDefinition describes how a specialized agent should behave.
+// Agents can be defined in .zyhive/agents/*.md (YAML frontmatter + system prompt body)
+// or registered programmatically as built-in agents.
+type AgentDefinition struct {
+	// AgentType is the unique identifier (e.g. "general-purpose", "researcher").
+	AgentType string `json:"agentType" yaml:"agentType"`
+
+	// WhenToUse describes when this agent should be chosen.
+	// Shown to the LLM so it can select the right agent.
+	WhenToUse string `json:"whenToUse" yaml:"whenToUse"`
+
+	// Description is a human-readable description shown in the UI.
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// ── Tool permissions ──────────────────────────────────────────────────────
+
+	// Tools lists allowed tool names. Use ["*"] to allow all.
+	// If empty, inherits the default tool set.
+	Tools []string `json:"tools,omitempty" yaml:"tools,omitempty"`
+
+	// DisallowedTools lists tool names explicitly forbidden for this agent.
+	DisallowedTools []string `json:"disallowedTools,omitempty" yaml:"disallowedTools,omitempty"`
+
+	// ── Execution ─────────────────────────────────────────────────────────────
+
+	// Model overrides the default model. "inherit" = use parent's model.
+	Model string `json:"model,omitempty" yaml:"model,omitempty"`
+
+	// MaxTurns caps the number of LLM turns (0 = no limit).
+	MaxTurns int `json:"maxTurns,omitempty" yaml:"maxTurns,omitempty"`
+
+	// PermissionMode controls how permission prompts are handled.
+	// "" | "default" | "plan" | "acceptEdits" | "bypassPermissions"
+	PermissionMode string `json:"permissionMode,omitempty" yaml:"permissionMode,omitempty"`
+
+	// Background makes this agent always run in the background when spawned.
+	Background bool `json:"background,omitempty" yaml:"background,omitempty"`
+
+	// ── Context optimization ──────────────────────────────────────────────────
+
+	// OmitProjectFiles skips injecting CLAUDE.md/project files into the system prompt.
+	// Use for read-only agents (research, plan) that don't need commit/PR guidelines.
+	// Saves significant tokens on high-volume spawns.
+	OmitProjectFiles bool `json:"omitProjectFiles,omitempty" yaml:"omitProjectFiles,omitempty"`
+
+	// CriticalSystemReminder is a short string re-injected at every user turn.
+	// Use for constraints that must never be forgotten (e.g. "do not modify files").
+	CriticalSystemReminder string `json:"criticalSystemReminder,omitempty" yaml:"criticalSystemReminder,omitempty"`
+
+	// ── Memory and skills ─────────────────────────────────────────────────────
+
+	// Skills lists skill names to preload when this agent starts.
+	Skills []string `json:"skills,omitempty" yaml:"skills,omitempty"`
+
+	// Memory sets the persistent memory scope for this agent.
+	// "user" (~/.zyhive/agent-memory/), "project" (.zyhive/agent-memory/), "local"
+	Memory string `json:"memory,omitempty" yaml:"memory,omitempty"`
+
+	// ── Initial prompt ────────────────────────────────────────────────────────
+
+	// InitialPrompt is prepended to the first user turn.
+	// Useful for loading skill content or injecting bootstrapping context.
+	InitialPrompt string `json:"initialPrompt,omitempty" yaml:"initialPrompt,omitempty"`
+
+	// ── Source ────────────────────────────────────────────────────────────────
+
+	// Source indicates where this definition came from.
+	// "built-in" | "user" | "project" | "plugin"
+	Source string `json:"source" yaml:"source"`
+
+	// SystemPrompt is the agent's base system prompt (body of the .md file).
+	// For built-in agents this is set programmatically.
+	SystemPrompt string `json:"systemPrompt,omitempty" yaml:"-"`
+}
+
+// ─── Built-in Agent Definitions ──────────────────────────────────────────────
+// Mirrors Claude Code's built-in agent types.
+
+var BuiltInAgentDefinitions = []AgentDefinition{
+	{
+		AgentType: "general-purpose",
+		WhenToUse: "通用 Agent，用于研究复杂问题、搜索代码、执行多步任务。当你不确定在哪里找到某个关键字或文件时，使用此 Agent 进行搜索。",
+		Tools:     []string{"*"},
+		Source:    "built-in",
+		SystemPrompt: `你是一个通用 Agent。根据用户的消息，使用可用的工具完成任务。
+彻底完成任务——不镀金，但也不半途而废。
+
+**优势：**
+- 在大型代码库中搜索代码、配置和模式
+- 分析多个文件以理解系统架构
+- 调查需要探索许多文件的复杂问题
+- 执行多步研究任务
+
+**准则：**
+- 文件搜索：不知道位置时广泛搜索
+- 分析：先宏观后细节，尝试多种搜索策略
+- 要彻底：检查多个位置，考虑不同命名约定
+- 除非绝对必要，否则不创建文件
+- 完成后，简洁报告完成的内容和关键发现`,
+	},
+	{
+		AgentType:        "explore",
+		WhenToUse:        "只读探索 Agent，用于代码库调研和理解，不修改任何文件。",
+		Tools:            []string{"Read", "Glob", "Grep", "WebSearch", "WebFetch"},
+		OmitProjectFiles: true, // 只读Agent不需要提交/PR规范，省token
+		CriticalSystemReminder: "你是只读探索 Agent。禁止创建、修改或删除任何文件。",
+		Source:           "built-in",
+		SystemPrompt: `你是一个探索 Agent，专门用于代码库调研。
+**严格只读**：不得创建、修改或删除任何文件。
+报告你的发现，不执行任何修改操作。`,
+	},
+	{
+		AgentType:        "plan",
+		WhenToUse:        "规划 Agent，制定详细实施方案。只读，不执行任何修改。",
+		Tools:            []string{"Read", "Glob", "Grep"},
+		OmitProjectFiles: true,
+		PermissionMode:   "plan",
+		CriticalSystemReminder: "你是规划 Agent。只制定计划，不执行修改。",
+		Source:           "built-in",
+		SystemPrompt: `你是一个规划 Agent。
+阅读代码库，制定详细、可执行的实施计划。
+包含具体文件路径、函数名、修改内容。
+**不执行任何修改**——只输出计划。`,
+	},
+	{
+		AgentType: "verification",
+		WhenToUse: "验证 Agent，独立验证其他 Agent 的工作成果。用新鲜视角检验，不继承实现 Agent 的假设。",
+		Tools:     []string{"Read", "Glob", "Grep", "Bash"},
+		Source:    "built-in",
+		SystemPrompt: `你是一个验证 Agent。
+**真正验证**意味着证明代码有效，而不仅仅是确认它存在。
+
+- 运行测试并关注失败
+- 运行类型检查并调查错误
+- 持怀疑态度——看起来不对就深入调查
+- 独立验证——证明变更有效，不要橡皮图章
+- 尝试边缘情况和错误路径`,
+	},
+	{
+		AgentType: "coordinator",
+		WhenToUse: "协调者 Agent，负责分解复杂任务、指挥多个 Worker 并行工作、综合结果。",
+		Tools:     []string{"dispatch_task", "send_message_to_agent"},
+		Source:    "built-in",
+	},
+}
+
+// GetBuiltInAgent returns a built-in agent definition by type name.
+// Returns nil if not found.
+func GetBuiltInAgent(agentType string) *AgentDefinition {
+	for i := range BuiltInAgentDefinitions {
+		if BuiltInAgentDefinitions[i].AgentType == agentType {
+			cp := BuiltInAgentDefinitions[i]
+			return &cp
+		}
+	}
+	return nil
+}
+
+// IsReadOnlyAgent returns true if this agent type is known to be read-only.
+// Read-only agents skip project file injection to save tokens.
+func (d *AgentDefinition) IsReadOnlyAgent() bool {
+	return d.OmitProjectFiles ||
+		d.AgentType == "explore" ||
+		d.AgentType == "plan"
+}
+
+// EffectiveModel returns the model to use for this agent.
+// "inherit" or "" means use the spawner's model.
+func (d *AgentDefinition) EffectiveModel(parentModel string) string {
+	if d.Model == "" || d.Model == "inherit" {
+		return parentModel
+	}
+	return d.Model
+}

--- a/pkg/memory/session_memory.go
+++ b/pkg/memory/session_memory.go
@@ -1,0 +1,308 @@
+// Package memory — Session Memory: background AI extraction of conversation notes.
+// Inspired by Claude Code's services/SessionMemory/sessionMemory.ts
+//
+// How it works:
+//   1. After each LLM turn, check if extraction thresholds are met
+//   2. If so, spawn a background restricted agent that reads the current
+//      session-memory.md and updates it with key insights from the conversation
+//   3. On the next compaction, inject session-memory.md into the system prompt
+//      so the agent has continuity even after history is truncated
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+// SessionMemoryConfig controls when automatic extraction triggers.
+type SessionMemoryConfig struct {
+	// MinTokensToInit is the minimum estimated token count before the first extraction.
+	// Default: 10000
+	MinTokensToInit int
+
+	// MinTokensBetweenUpdates is the minimum token growth between extractions.
+	// Default: 5000
+	MinTokensBetweenUpdates int
+
+	// ToolCallsBetweenUpdates is the minimum tool call count between extractions.
+	// Default: 3
+	ToolCallsBetweenUpdates int
+}
+
+var DefaultSessionMemoryConfig = SessionMemoryConfig{
+	MinTokensToInit:         10000,
+	MinTokensBetweenUpdates: 5000,
+	ToolCallsBetweenUpdates: 3,
+}
+
+// ─── Template ─────────────────────────────────────────────────────────────────
+
+// DefaultSessionMemoryTemplate is the markdown template for session notes.
+// Directly adapted from Claude Code's DEFAULT_SESSION_MEMORY_TEMPLATE.
+const DefaultSessionMemoryTemplate = `# 会话标题
+_5-10词描述性标题，信息密集，无废话_
+
+# 当前状态
+_当前在做什么？未完成的任务？立即下一步？_
+
+# 任务规格
+_用户要求做什么？设计决策？背景信息？_
+
+# 重要文件
+_关键文件及其作用？_
+
+# 工作流程
+_常用命令及顺序？输出如何解读？_
+
+# 错误和修正
+_遇到的错误及修复方法？失败的方案（不要重试）？_
+
+# 代码库文档
+_重要系统组件？它们如何协作？_
+
+# 经验教训
+_有效的方法？无效的？要避免的？_
+
+# 关键结果
+_用户要求的具体输出（完整保留）_
+
+# 工作日志
+_每步的简要记录_
+`
+
+// ─── State tracker ────────────────────────────────────────────────────────────
+
+// SessionMemoryState tracks extraction state per session.
+type SessionMemoryState struct {
+	mu                  sync.Mutex
+	initialized         bool
+	tokensAtLastExtract int
+	toolCallsSinceLast  int
+	extracting          bool
+	lastExtractAt       time.Time
+}
+
+// ShouldExtract returns true if extraction thresholds are met.
+func (s *SessionMemoryState) ShouldExtract(currentTokens, toolCallsTotal int, cfg SessionMemoryConfig) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.extracting {
+		return false // already running
+	}
+
+	// Initialization threshold
+	if !s.initialized {
+		if currentTokens < cfg.MinTokensToInit {
+			return false
+		}
+		s.initialized = true
+	}
+
+	// Token growth threshold (always required)
+	tokenGrowth := currentTokens - s.tokensAtLastExtract
+	if tokenGrowth < cfg.MinTokensBetweenUpdates {
+		return false
+	}
+
+	// Tool call threshold
+	if toolCallsTotal < cfg.ToolCallsBetweenUpdates {
+		return false
+	}
+
+	return true
+}
+
+func (s *SessionMemoryState) MarkExtracting() {
+	s.mu.Lock()
+	s.extracting = true
+	s.mu.Unlock()
+}
+
+func (s *SessionMemoryState) MarkDone(currentTokens int) {
+	s.mu.Lock()
+	s.extracting = false
+	s.initialized = true
+	s.tokensAtLastExtract = currentTokens
+	s.toolCallsSinceLast = 0
+	s.lastExtractAt = time.Now()
+	s.mu.Unlock()
+}
+
+func (s *SessionMemoryState) IncrToolCalls() {
+	s.mu.Lock()
+	s.toolCallsSinceLast++
+	s.mu.Unlock()
+}
+
+// ─── Manager ──────────────────────────────────────────────────────────────────
+
+// SessionMemoryManager handles background extraction for a single agent's sessions.
+type SessionMemoryManager struct {
+	workspaceDir string
+	cfg          SessionMemoryConfig
+	states       sync.Map // sessionID → *SessionMemoryState
+
+	// runExtractFn is called to run the extraction agent.
+	// agentID, sessionID (isolated), memoryPath, currentContent, conversationJSON
+	runExtractFn ExtractFunc
+}
+
+// ExtractFunc runs an extraction pass.
+// conversation is the JSON-serialized message history.
+// memoryPath is the file to update.
+// currentContent is the current file content.
+type ExtractFunc func(ctx context.Context, agentID, memoryPath, currentContent, conversationJSON string) error
+
+// NewSessionMemoryManager creates a manager for the given workspace.
+func NewSessionMemoryManager(workspaceDir string, cfg SessionMemoryConfig, fn ExtractFunc) *SessionMemoryManager {
+	return &SessionMemoryManager{
+		workspaceDir: workspaceDir,
+		cfg:          cfg,
+		runExtractFn: fn,
+	}
+}
+
+func (m *SessionMemoryManager) getState(sessionID string) *SessionMemoryState {
+	v, _ := m.states.LoadOrStore(sessionID, &SessionMemoryState{})
+	return v.(*SessionMemoryState)
+}
+
+// GetOrCreateMemoryFile ensures session-memory.md exists and returns its path and content.
+func (m *SessionMemoryManager) GetOrCreateMemoryFile(agentID string) (string, string, error) {
+	dir := filepath.Join(m.workspaceDir, ".zyhive", "session-memory")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", "", err
+	}
+	path := filepath.Join(dir, agentID+".md")
+
+	// Create with template if not exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.WriteFile(path, []byte(DefaultSessionMemoryTemplate), 0600); err != nil {
+			return "", "", err
+		}
+		return path, DefaultSessionMemoryTemplate, nil
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", err
+	}
+	return path, string(content), nil
+}
+
+// MaybeExtract checks thresholds and triggers background extraction if needed.
+// messages is the JSON-serialized conversation history.
+// currentTokens is the estimated token count.
+// Returns immediately; extraction runs in background.
+func (m *SessionMemoryManager) MaybeExtract(
+	ctx context.Context,
+	agentID, sessionID string,
+	messages []map[string]any,
+	currentTokens int,
+) {
+	state := m.getState(sessionID)
+
+	// Count tool calls in messages
+	toolCalls := 0
+	for _, msg := range messages {
+		if role, _ := msg["role"].(string); role == "assistant" {
+			if content, ok := msg["content"].([]any); ok {
+				for _, block := range content {
+					if b, ok := block.(map[string]any); ok {
+						if b["type"] == "tool_use" {
+							toolCalls++
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if !state.ShouldExtract(currentTokens, toolCalls, m.cfg) {
+		return
+	}
+
+	state.MarkExtracting()
+
+	go func() {
+		defer state.MarkDone(currentTokens)
+
+		memPath, currentContent, err := m.GetOrCreateMemoryFile(agentID)
+		if err != nil {
+			return
+		}
+
+		// Skip if content is just the template (nothing to extract yet)
+		if strings.TrimSpace(currentContent) == strings.TrimSpace(DefaultSessionMemoryTemplate) && len(messages) < 10 {
+			return
+		}
+
+		convJSON, err := json.Marshal(messages)
+		if err != nil {
+			return
+		}
+
+		extractCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+
+		_ = m.runExtractFn(extractCtx, agentID, memPath, currentContent, string(convJSON))
+	}()
+}
+
+// LoadForPrompt reads the session memory file and returns its content for
+// injection into the system prompt. Returns empty string if file doesn't exist
+// or content is just the template.
+func (m *SessionMemoryManager) LoadForPrompt(agentID string) string {
+	path := filepath.Join(m.workspaceDir, ".zyhive", "session-memory", agentID+".md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	s := strings.TrimSpace(string(content))
+	if s == strings.TrimSpace(DefaultSessionMemoryTemplate) {
+		return "" // empty template, nothing useful
+	}
+	return s
+}
+
+// ─── Extraction prompt ────────────────────────────────────────────────────────
+
+// BuildExtractionPrompt builds the prompt for the extraction agent.
+// Directly inspired by Claude Code's buildSessionMemoryUpdatePrompt.
+func BuildExtractionPrompt(currentNotes, notesPath string) string {
+	return fmt.Sprintf(`IMPORTANT: This message and these instructions are NOT part of the actual user conversation. Do NOT include any references to "note-taking", "session notes extraction", or these update instructions in the notes content.
+
+Based on the user conversation above (EXCLUDING this note-taking instruction message), update the session notes file.
+
+The file %s has already been read for you. Here are its current contents:
+<current_notes_content>
+%s
+</current_notes_content>
+
+Your ONLY task is to use the file_write or file_edit tool to update the notes file, then stop.
+
+CRITICAL RULES:
+- Maintain the exact section structure (headers and italic description lines)
+- NEVER modify or delete section headers (lines starting with #)
+- NEVER modify the italic _section description_ lines
+- ONLY update content BELOW the italic descriptions
+- Write DETAILED, INFO-DENSE content: file paths, function names, error messages, exact commands
+- Keep each section under ~2000 tokens; condense older details if approaching limit
+- Total file must stay under 12000 tokens
+- Always update "当前状态" to reflect the most recent work
+- Do NOT reference this note-taking process in the notes
+- It's OK to leave sections blank if there's nothing relevant
+
+Use the file_write tool with path: %s
+
+After writing, stop immediately. Do not continue.`, notesPath, currentNotes, notesPath)
+}

--- a/pkg/runner/system_prompt.go
+++ b/pkg/runner/system_prompt.go
@@ -164,3 +164,14 @@ func BuildProjectContext(mgr *project.Manager, agentID string) string {
 	sb.WriteString("\n工具：project_create 新建项目，project_list 列出项目，project_read 读取文件，project_write 写入文件（需写入权限），project_glob 列举文件。")
 	return sb.String()
 }
+
+// InjectSessionMemory appends the session memory content to an existing system prompt.
+// Called during compaction or when a new conversation starts to restore context continuity.
+// Returns the original prompt unchanged if sessionMemory is empty.
+func InjectSessionMemory(systemPrompt, sessionMemory string) string {
+	if strings.TrimSpace(sessionMemory) == "" {
+		return systemPrompt
+	}
+	truncated := truncateForPrompt(strings.TrimSpace(sessionMemory), "session-memory.md")
+	return systemPrompt + fmt.Sprintf("\n\n--- 会话记忆（上次对话摘要）---\n%s\n", truncated)
+}

--- a/pkg/subagent/coordinator.go
+++ b/pkg/subagent/coordinator.go
@@ -1,0 +1,161 @@
+// Package subagent — Coordinator mode prompts and task-notification XML format.
+// Inspired by Claude Code's coordinator/coordinatorMode.ts
+package subagent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ─── Coordinator System Prompt ────────────────────────────────────────────────
+
+// CoordinatorSystemPrompt is the system prompt injected when an agent acts as
+// a Coordinator (orchestrating multiple Workers). Directly inspired by Claude Code.
+const CoordinatorSystemPrompt = `你是 ZyHive 团队协调者（Coordinator）。
+
+## 1. 你的角色
+
+你是**协调者**。你的职责：
+- 帮助用户实现目标
+- 指导 Worker 研究、实现、验证
+- 综合结果并与用户沟通
+- 能直接回答的问题不要派遣给 Worker
+
+发给用户的每条消息都是真正面向用户的。Worker 的结果和系统通知是内部信号——不要感谢或确认它们。有新信息时及时向用户总结。
+
+## 2. 工作阶段
+
+| 阶段 | 执行者 | 目的 |
+|------|--------|------|
+| 研究 | Workers（并行）| 调查代码库、理解问题 |
+| 综合 | **你**（Coordinator）| 读懂研究结果，制定具体实施规格 |
+| 实现 | Workers | 按规格修改代码、提交 |
+| 验证 | Workers | 独立验证成果 |
+
+## 3. 并发原则
+
+**并行是你的超能力。Worker 是异步的。同时启动多个独立 Worker，不要串行执行可以并行的任务。**
+
+- 只读任务（研究）→ 自由并行
+- 写入任务（实现）→ 同一文件集一次一个
+- 验证有时可以和实现在不同文件区域并行
+
+## 4. Worker 结果处理
+
+Worker 完成后发来 XML 格式通知。根据 task_id 使用 dispatch_task 的 continue_task 继续该 Worker，或者 spawn 新 Worker。
+
+## 5. Continue vs Spawn 决策
+
+| 情形 | 策略 | 原因 |
+|------|------|------|
+| 研究探索的文件正好要改 | Continue | Worker 已有上下文 |
+| 研究范围宽，实现很窄 | Spawn | 清洁上下文更好 |
+| 纠正失败的尝试 | Continue | Worker 有错误上下文 |
+| 验证另一 Worker 的代码 | Spawn | 新鲜视角，不带实现假设 |
+| 方法完全错误 | Spawn | 避免锚定效应 |
+| 完全无关的任务 | Spawn | 没有可复用的上下文 |
+
+## 6. 综合原则（最重要的工作）
+
+研究完成后，**必须是你来理解**结果，然后写包含具体文件路径、行号、修改内容的规格说明。
+禁止写"根据你的发现"或"根据研究"——这是把理解外包给 Worker。
+好的规格说明一眼就能看出你真正读懂了研究结果。
+
+## 7. Worker 提示词要点
+
+Workers 看不到你和用户的对话。每个提示词必须自包含：
+- 包含具体文件路径、行号、错误信息
+- 说明"完成"意味着什么
+- 实现任务末尾加：运行相关测试和类型检查，提交并报告 commit hash
+- 研究任务末尾加：报告发现，不修改文件
+- 禁止写"根据你的发现"——综合是你的工作`
+
+// ─── Task Notification XML ────────────────────────────────────────────────────
+
+// TaskNotification holds the result of a completed Worker task.
+// Serialized to <task-notification> XML and injected into the Coordinator's message stream.
+type TaskNotification struct {
+	TaskID   string
+	Status   string // "completed" | "failed" | "killed"
+	Summary  string
+	Result   string
+	Usage    NotificationUsage
+}
+
+// NotificationUsage carries performance metadata for a completed task.
+type NotificationUsage struct {
+	TotalTokens int
+	ToolUses    int
+	DurationMs  int64
+}
+
+// FormatXML renders the notification as a <task-notification> XML block.
+// This format mirrors Claude Code's coordinator task notification format.
+func (n TaskNotification) FormatXML() string {
+	var sb strings.Builder
+	sb.WriteString("<task-notification>\n")
+	sb.WriteString(fmt.Sprintf("<task-id>%s</task-id>\n", n.TaskID))
+	sb.WriteString(fmt.Sprintf("<status>%s</status>\n", n.Status))
+	sb.WriteString(fmt.Sprintf("<summary>%s</summary>\n", escapeXML(n.Summary)))
+	if n.Result != "" {
+		sb.WriteString(fmt.Sprintf("<result>%s</result>\n", escapeXML(n.Result)))
+	}
+	sb.WriteString("<usage>\n")
+	sb.WriteString(fmt.Sprintf("  <total_tokens>%d</total_tokens>\n", n.Usage.TotalTokens))
+	sb.WriteString(fmt.Sprintf("  <tool_uses>%d</tool_uses>\n", n.Usage.ToolUses))
+	sb.WriteString(fmt.Sprintf("  <duration_ms>%d</duration_ms>\n", n.Usage.DurationMs))
+	sb.WriteString("</usage>\n")
+	sb.WriteString("</task-notification>")
+	return sb.String()
+}
+
+// BuildTaskNotification creates a TaskNotification from a completed Task.
+func BuildTaskNotification(task *Task) TaskNotification {
+	status := "completed"
+	switch task.Status {
+	case TaskError:
+		status = "failed"
+	case TaskKilled:
+		status = "killed"
+	}
+
+	summary := fmt.Sprintf("Agent \"%s\" %s", task.Label, statusSummary(task.Status))
+	if task.ErrorMsg != "" {
+		summary += ": " + task.ErrorMsg
+	}
+
+	durationMs := int64(0)
+	if task.StartedAt > 0 && task.EndedAt > 0 {
+		durationMs = task.EndedAt - task.StartedAt
+	}
+
+	return TaskNotification{
+		TaskID:  task.ID,
+		Status:  status,
+		Summary: summary,
+		Result:  task.Output,
+		Usage: NotificationUsage{
+			DurationMs: durationMs,
+		},
+	}
+}
+
+func statusSummary(s TaskStatus) string {
+	switch s {
+	case TaskDone:
+		return "completed"
+	case TaskError:
+		return "failed"
+	case TaskKilled:
+		return "was stopped"
+	default:
+		return string(s)
+	}
+}
+
+func escapeXML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}

--- a/pkg/subagent/manager.go
+++ b/pkg/subagent/manager.go
@@ -28,7 +28,9 @@ type RunFunc func(ctx context.Context, agentID, model, sessionID, parentSessionI
 
 // NotifyFunc is called when a task completes. It can inject a system message
 // back into the parent session / send a Telegram notification.
-type NotifyFunc func(spawnedBy, spawnedBySession, taskID, label, output string, status TaskStatus)
+// The xml parameter contains the pre-formatted <task-notification> XML block
+// that should be injected as a user-role message into the parent session.
+type NotifyFunc func(spawnedBy, spawnedBySession, taskID, label, output, xml string, status TaskStatus)
 
 // ContextReadFn reads the last N conversation turns from the given session.
 type ContextReadFn func(sessionID string, lastN int) string
@@ -482,9 +484,11 @@ func (m *Manager) runTask(ctx context.Context, task *Task, enrichedTask string) 
 		Timestamp:         time.Now().UnixMilli(),
 	})
 
-	// Notify parent
+	// Notify parent with task-notification XML (Coordinator pattern)
 	if m.notify != nil && task.SpawnedBy != "" {
-		m.notify(task.SpawnedBy, task.SpawnedBySession, task.ID, task.Label, outputBuf, task.Status)
+		notif := BuildTaskNotification(task)
+		notifXML := notif.FormatXML()
+		m.notify(task.SpawnedBy, task.SpawnedBySession, task.ID, task.Label, outputBuf, notifXML, task.Status)
 	}
 }
 


### PR DESCRIPTION
## 本次升级

借鉴 Claude Code v2.1.88 泄露源码，对 ZyHive 团队系统进行三大核心升级。

---

## 1. Coordinator 模式（`pkg/subagent/coordinator.go`）

完整的协调者系统提示词，直接可用：
- 研究→综合→实现→验证四阶段工作流
- **Continue vs Spawn 决策矩阵**（什么时候继续原 Worker，什么时候 Spawn 新 Worker）
- 并行化原则：独立任务必须同时启动
- 综合原则：禁止"根据你的发现"懒惰委托

**`<task-notification>` XML 格式**：子 Agent 完成时自动生成并注入父会话，Coordinator 可感知并决定下一步。

## 2. AgentDefinition 标准化（`pkg/agent/definition.go`）

统一的 Agent 定义结构，5 个内置 Agent 类型：
- `general-purpose` 通用
- `explore` 只读探索（跳过 project files 省 token，对标 CC 的 omitClaudeMd）  
- `plan` 只规划不执行
- `verification` 独立验证（新鲜视角）
- `coordinator` 指挥官

关键字段：`OmitProjectFiles`、`CriticalSystemReminder`（每轮注入的约束）、`Memory scope`

## 3. SessionMemory 后台提取（`pkg/memory/session_memory.go`）

CC 最核心的记忆功能：**后台 AI 自动提取会话记忆**

触发机制（双阈值）：
- token 增长 ≥ 5000 AND 工具调用 ≥ 3 次

10 个章节模板（直接借鉴 CC）：会话标题、当前状态、任务规格、重要文件、工作流程、错误修正、代码库文档、经验教训、关键结果、工作日志

压缩时自动注入 system prompt，实现跨会话上下文连续性。

## 变更文件

| 文件 | 类型 | 说明 |
|------|------|------|
| `pkg/subagent/coordinator.go` | 新增 | Coordinator提示词 + task-notification XML |
| `pkg/agent/definition.go` | 新增 | AgentDefinition结构 + 内置Agent定义 |
| `pkg/memory/session_memory.go` | 新增 | SessionMemory后台提取 |
| `pkg/subagent/manager.go` | 修改 | NotifyFunc增加xml参数 |
| `pkg/runner/system_prompt.go` | 修改 | InjectSessionMemory注入函数 |
| `cmd/aipanel/main.go` | 修改 | notify回调升级，同时注入XML和摘要 |

## 待集成（下一步）

这次 PR 提供了底层基础设施。还需要：
1. 在 `pkg/runner/runner.go` 的 `Run()` 中调用 `MaybeExtract()`
2. 在 `pool.go` 中根据 `AgentDefinition` 动态配置 Agent 的工具集和系统提示词
3. 为 Coordinator 类型 Agent 注入 `CoordinatorSystemPrompt`
4. Mailbox 消息系统（下一个 PR）