### PR TITLE
fix(network): 通讯录 5 个漏网 bug 修复 (P0.5 全绿)

### DIFF
--- a/internal/api/public_chat.go
+++ b/internal/api/public_chat.go
@@ -286,7 +286,10 @@ func (h *publicChatHandler) runPublic(
 	var extraCtx string
 	if visitorToken != "" {
 		nstore := network.NewStore(workspaceDir)
-		if _, nerr := nstore.Resolve(network.SourceWeb, visitorToken, "Web 访客"); nerr == nil {
+		// Bug 2: 统一走 FallbackDisplayName — 对 Web 访客这里"Web 访客"作为
+		// 首选名, token 前缀兜底（visitorToken 可能是长 sid）.
+		name := network.FallbackDisplayName(visitorToken, "Web 访客")
+		if _, nerr := nstore.Resolve(network.SourceWeb, visitorToken, name); nerr == nil {
 			extraCtx = nstore.Summary(network.MakeID(network.SourceWeb, visitorToken))
 		}
 	}

--- a/internal/api/relations.go
+++ b/internal/api/relations.go
@@ -38,9 +38,18 @@ type relationsHandler struct {
 }
 
 // RelationRow is one row from RELATIONS.md.
+//
+// The ToKind field (added in 26.4.23v1) distinguishes between agent-to-agent
+// relations and agent-to-contact relations:
+//   - "agent"   → target is another AI member (default; legacy rows)
+//   - "contact" → target is a real person from network/contacts/
+//
+// TeamView graph only renders agent-kind edges; contact-kind edges exist
+// purely for the AI's system prompt context (relation awareness).
 type RelationRow struct {
 	AgentID      string `json:"agentId"`
 	AgentName    string `json:"agentName"`
+	ToKind       string `json:"toKind,omitempty"` // "agent" (default) | "contact"
 	RelationType string `json:"relationType"`
 	Strength     string `json:"strength"`
 	Desc         string `json:"desc"`
@@ -371,18 +380,29 @@ func (h *relationsHandler) ClearAllRelations(c *gin.Context) {
 }
 
 // writeRelationsFile serializes RelationRows as a markdown table and writes to disk.
+// New format (6 cols): | 目标ID | 目标名称 | 类型 | 关系 | 程度 | 说明 |
+//
+//	类型 = "agent" | "contact"
+//
+// Old format (5 cols) is still readable by parseRelationsMarkdown for back-compat.
 func writeRelationsFile(filePath string, rows []RelationRow) error {
 	if len(rows) == 0 {
 		return os.WriteFile(filePath, []byte(""), 0644)
 	}
 	var sb strings.Builder
-	sb.WriteString("| 成员ID | 成员名称 | 关系类型 | 关系程度 | 说明 |\n")
-	sb.WriteString("|--------|--------|--------|--------|------|\n")
+	sb.WriteString("| 目标ID | 目标名称 | 类型 | 关系 | 程度 | 说明 |\n")
+	sb.WriteString("|--------|--------|------|------|------|------|\n")
 	for _, r := range rows {
+		kind := r.ToKind
+		if kind == "" {
+			kind = "agent"
+		}
 		sb.WriteString("| ")
 		sb.WriteString(r.AgentID)
 		sb.WriteString(" | ")
 		sb.WriteString(r.AgentName)
+		sb.WriteString(" | ")
+		sb.WriteString(kind)
 		sb.WriteString(" | ")
 		sb.WriteString(r.RelationType)
 		sb.WriteString(" | ")
@@ -428,6 +448,17 @@ func (h *relationsHandler) Graph(c *gin.Context) {
 
 		rows := parseRelationsMarkdown(string(data))
 		for _, row := range rows {
+			// Bug 4 fix: skip contact edges entirely — TeamView graph only
+			// renders AI member network. Contact relations are surfaced in
+			// the separate "联系人" tab.
+			kind := row.ToKind
+			if kind == "" {
+				kind = "agent"
+			}
+			if kind != "agent" {
+				continue
+			}
+
 			// Ensure target node is present
 			if _, exists := nodeMap[row.AgentID]; !exists {
 				nodeMap[row.AgentID] = GraphNode{ID: row.AgentID, Name: row.AgentName, Status: "idle"}
@@ -563,38 +594,65 @@ func parseRelationsMarkdown(content string) []RelationRow {
 			continue
 		}
 
+		// Two formats supported:
+		//   6 cols: | id | name | toKind | type | strength | desc |   (26.4.23v1+)
+		//   5 cols: | id | name | type | strength | desc |            (legacy)
 		agentName := ""
+		toKind := ""
 		relationType := ""
 		strength := ""
 		desc := ""
 		if len(cols) > 1 {
 			agentName = cols[1]
 		}
-		if len(cols) > 2 {
-			relationType = cols[2]
+		if len(cols) >= 6 {
+			// New format with toKind column
+			toKind = cols[2]
+			relationType = cols[3]
+			strength = cols[4]
+			desc = cols[5]
+		} else {
+			// Legacy 5-column format (toKind defaults to "agent")
+			if len(cols) > 2 {
+				relationType = cols[2]
+			}
+			if len(cols) > 3 {
+				strength = cols[3]
+			}
+			if len(cols) > 4 {
+				desc = cols[4]
+			}
 		}
-		if len(cols) > 3 {
-			strength = cols[3]
-		}
-		if len(cols) > 4 {
-			desc = cols[4]
+		if toKind == "" {
+			toKind = "agent"
 		}
 
-		// Validate: relationType must be one of the known values (keep legacy 上级/下级 readable)
-		validTypes := map[string]bool{"上下级": true, "上级": true, "下级": true, "平级协作": true, "支持": true, "其他": true}
+		// Validate: relationType must be one of the known values.
+		// Agent-agent: 上下级/上级/下级/平级协作/支持/其他
+		// Contact relations add: 服务/客户/家人/朋友/同事/合作伙伴
+		validTypes := map[string]bool{
+			"上下级": true, "上级": true, "下级": true,
+			"平级协作": true, "支持": true, "其他": true,
+			"服务": true, "客户": true, "家人": true,
+			"朋友": true, "同事": true, "合作伙伴": true,
+		}
 		if relationType != "" && !validTypes[relationType] {
 			continue
 		}
 
-		// Dedup by agentId
-		if seen[first] {
+		// Dedup by (agentId, toKind) pair — an agent could have both
+		// an "agent" relation and a "contact" relation with the same target ID,
+		// although in practice IDs are namespaced (contact IDs contain ":").
+		dedupKey := first + "|" + toKind
+		if seen[dedupKey] {
 			continue
 		}
-		seen[first] = true
+		seen[dedupKey] = true
 
 		rows = append(rows, RelationRow{
 			AgentID:      first,
 			AgentName:    agentName,
+			ToKind:       toKind,
 			RelationType: relationType,
 			Strength:     strength,
 			Desc:         desc,

--- a/internal/api/relations_test.go
+++ b/internal/api/relations_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestParseRelationsMarkdown6ColNewFormat verifies the new 6-column format
+// with toKind (26.4.23v1+) is parsed correctly and round-trips safely.
+func TestParseRelationsMarkdown6ColNewFormat(t *testing.T) {
+	content := `| 目标ID | 目标名称 | 类型 | 关系 | 程度 | 说明 |
+|--------|--------|------|------|------|------|
+| abao | 阿宝 | agent | 平级协作 | 常用 | AI 伴侣 |
+| feishu:ou_abc | 张三 | contact | 服务 | 强 | 客户 |
+| telegram:999 | Lilian | contact | 家人 | 强 |  |
+`
+	rows := parseRelationsMarkdown(content)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d: %+v", len(rows), rows)
+	}
+
+	// Row 0: agent
+	if rows[0].AgentID != "abao" {
+		t.Fatalf("row[0].AgentID = %q", rows[0].AgentID)
+	}
+	if rows[0].ToKind != "agent" {
+		t.Fatalf("row[0].ToKind = %q, want agent", rows[0].ToKind)
+	}
+	if rows[0].RelationType != "平级协作" {
+		t.Fatalf("row[0].RelationType = %q", rows[0].RelationType)
+	}
+
+	// Row 1: contact with "服务" (new valid type)
+	if rows[1].AgentID != "feishu:ou_abc" {
+		t.Fatalf("row[1].AgentID = %q", rows[1].AgentID)
+	}
+	if rows[1].ToKind != "contact" {
+		t.Fatalf("row[1].ToKind = %q, want contact", rows[1].ToKind)
+	}
+	if rows[1].RelationType != "服务" {
+		t.Fatalf("row[1].RelationType = %q", rows[1].RelationType)
+	}
+
+	// Row 2: contact with "家人"
+	if rows[2].ToKind != "contact" || rows[2].RelationType != "家人" {
+		t.Fatalf("row[2] mismatch: %+v", rows[2])
+	}
+}
+
+// TestParseRelationsMarkdown5ColLegacy verifies legacy 5-column rows still
+// parse, with toKind defaulting to "agent".
+func TestParseRelationsMarkdown5ColLegacy(t *testing.T) {
+	content := `| 成员ID | 成员名称 | 关系类型 | 关系程度 | 说明 |
+|--------|--------|--------|--------|------|
+| abao | 阿宝 | 平级协作 | 常用 | AI 伴侣 |
+| boss | 老板 | 上级 | 强 | 报告线 |
+`
+	rows := parseRelationsMarkdown(content)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	for i, r := range rows {
+		if r.ToKind != "agent" {
+			t.Fatalf("row[%d].ToKind = %q, legacy should default to agent", i, r.ToKind)
+		}
+	}
+	if rows[0].RelationType != "平级协作" || rows[1].RelationType != "上级" {
+		t.Fatalf("relation type parse wrong: %+v", rows)
+	}
+}
+
+// TestWriteRelationsFileRoundTrip verifies writing then re-parsing preserves
+// all fields including toKind.
+func TestWriteRelationsFileRoundTrip(t *testing.T) {
+	original := []RelationRow{
+		{AgentID: "abao", AgentName: "阿宝", ToKind: "agent", RelationType: "平级协作", Strength: "常用", Desc: "搭档"},
+		{AgentID: "feishu:ou_x", AgentName: "老板", ToKind: "contact", RelationType: "服务", Strength: "强", Desc: ""},
+	}
+	tmp := t.TempDir() + "/RELATIONS.md"
+	if err := writeRelationsFile(tmp, original); err != nil {
+		t.Fatal(err)
+	}
+	data, err := readTestFile(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(data, "contact") {
+		t.Fatalf("written file missing toKind column:\n%s", data)
+	}
+	rows := parseRelationsMarkdown(data)
+	if len(rows) != 2 {
+		t.Fatalf("round-trip row count mismatch: got %d", len(rows))
+	}
+	if rows[0].ToKind != "agent" || rows[1].ToKind != "contact" {
+		t.Fatalf("toKind not preserved: %+v", rows)
+	}
+	if rows[1].AgentID != "feishu:ou_x" {
+		t.Fatalf("contact ID lost: %+v", rows[1])
+	}
+}
+
+func readTestFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	return string(b), err
+}

--- a/pkg/channel/feishu.go
+++ b/pkg/channel/feishu.go
@@ -470,7 +470,9 @@ func (b *FeishuBot) handleMessageEvent(ctx context.Context, ev *feishuMessageEve
 	if b.agentDir != "" && senderOpenID != "" {
 		wsDir := filepath.Join(b.agentDir, "workspace")
 		store := network.NewStore(wsDir)
-		displayName := b.getSenderName(senderOpenID)
+		// Bug 2 fix: getSenderName 在刚加好友 / 群聊成员列表未拉取时会返回 "",
+		// 直接落盘会导致 UI 显示空白. 走 FallbackDisplayName 链.
+		displayName := network.FallbackDisplayName(senderOpenID, b.getSenderName(senderOpenID))
 		if _, nerr := store.Resolve(network.SourceFeishu, senderOpenID, displayName); nerr != nil {
 			log.Printf("[feishu] network.Resolve warning: %v", nerr)
 		} else if summary := store.Summary(network.MakeID(network.SourceFeishu, senderOpenID)); summary != "" {

--- a/pkg/channel/telegram.go
+++ b/pkg/channel/telegram.go
@@ -830,10 +830,9 @@ func (b *TelegramBot) generateAndSend(ctx context.Context, msg *TelegramMessage,
 		wsDir := filepath.Join(b.agentDir, "workspace")
 		store := network.NewStore(wsDir)
 		senderID := fmt.Sprintf("%d", msg.From.ID)
-		displayName := strings.TrimSpace(msg.From.FirstName)
-		if displayName == "" {
-			displayName = msg.From.Username
-		}
+		// Bug 2 fix: 完整 fallback 链 — firstName → username → externalID[:8]
+		// (TelegramUser 没有 LastName 字段, 见 pkg/channel/telegram.go#136)
+		displayName := network.FallbackDisplayName(senderID, msg.From.FirstName, msg.From.Username)
 		if _, nerr := store.Resolve(network.SourceTelegram, senderID, displayName); nerr != nil {
 			log.Printf("[telegram] network.Resolve warning: %v", nerr)
 		} else {

--- a/pkg/network/store.go
+++ b/pkg/network/store.go
@@ -53,6 +53,28 @@ func MakeID(source, externalID string) string {
 	return source + ":" + externalID
 }
 
+// FallbackDisplayName picks the first non-empty candidate as a human-readable
+// name. Used by channel inbound handlers where some platforms may not give a
+// nickname on first contact (e.g. Feishu before chatroom member list is loaded,
+// or Telegram users without FirstName/Username).
+//
+// The last fallback is a short prefix of the externalID so the UI never shows
+// an empty display name.
+func FallbackDisplayName(externalID string, candidates ...string) string {
+	for _, c := range candidates {
+		c = strings.TrimSpace(c)
+		if c != "" {
+			return c
+		}
+	}
+	// Short ID prefix as last resort. Keep it readable (8 chars is enough to
+	// distinguish most external IDs at a glance).
+	if len(externalID) > 8 {
+		return externalID[:8]
+	}
+	return externalID
+}
+
 // SplitID parses "source:externalId" — reverse of MakeID.
 func SplitID(id string) (source, externalID string, ok bool) {
 	i := strings.Index(id, ":")
@@ -124,9 +146,11 @@ func (s *Store) Delete(id string) error {
 }
 
 // Resolve is the canonical upsert. It is called by every inbound-message handler
-// (panel/feishu/telegram/web). If the contact already exists, it bumps
-// LastSeenAt / MsgCount and optionally updates DisplayName. If not, it creates
-// a fresh contact with the default body.
+// (panel/feishu/telegram/web). Behavior:
+//  1. If a contact file at {source}:{externalID} exists → bump LastSeenAt/MsgCount
+//  2. Else if another primary contact lists this ID in its `aliases` (i.e. the
+//     user has previously merged them) → route to that primary (Bug 3 fix)
+//  3. Else → create a new primary contact with the default body
 func (s *Store) Resolve(source, externalID, displayName string) (*Contact, error) {
 	if source == "" || externalID == "" {
 		return nil, fmt.Errorf("network.Resolve: source and externalID required")
@@ -154,6 +178,17 @@ func (s *Store) Resolve(source, externalID, displayName string) (*Contact, error
 		return existing, nil
 	}
 
+	// Bug 3 fix: 没有直接命中, 在扫一次 primary 档案的 aliases 字段.
+	// 如果该 ID 已被手动合并到某个 primary 下, 把消息计入 primary, 不新建.
+	if primary, perr := s.findPrimaryByAliasUnlocked(id); perr == nil && primary != nil {
+		primary.LastSeenAt = now
+		primary.MsgCount++
+		if err := s.saveUnlocked(primary); err != nil {
+			return nil, err
+		}
+		return primary, nil
+	}
+
 	c := &Contact{
 		ID:          id,
 		Source:      source,
@@ -168,6 +203,43 @@ func (s *Store) Resolve(source, externalID, displayName string) (*Contact, error
 		return nil, err
 	}
 	return c, nil
+}
+
+// findPrimaryByAliasUnlocked scans every primary contact file looking for one
+// whose Aliases contains aliasID. Caller must hold s.mu.
+// Returns (nil, nil) when not found. O(N) over file count; acceptable since
+// contact counts per agent are expected to be in the hundreds at most.
+func (s *Store) findPrimaryByAliasUnlocked(aliasID string) (*Contact, error) {
+	entries, err := os.ReadDir(s.contactsDir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.contactsDir(), e.Name()))
+		if err != nil {
+			continue
+		}
+		fallbackID := strings.TrimSuffix(e.Name(), ".md")
+		if i := strings.Index(fallbackID, "-"); i >= 0 {
+			fallbackID = fallbackID[:i] + ":" + fallbackID[i+1:]
+		}
+		c := parseContactMD(string(data), fallbackID)
+		if !c.Primary {
+			continue
+		}
+		for _, a := range c.Aliases {
+			if a == aliasID {
+				return c, nil
+			}
+		}
+	}
+	return nil, nil
 }
 
 // Touch bumps LastSeenAt / MsgCount without changing anything else. Used for

--- a/pkg/network/store_test.go
+++ b/pkg/network/store_test.go
@@ -128,6 +128,124 @@ func TestSummaryExtraction(t *testing.T) {
 	}
 }
 
+func TestResolveRoutesThroughAliases(t *testing.T) {
+	// Bug 3 regression: after manual merge, a later inbound message from the
+	// alias ID must bump the primary's MsgCount (not recreate an orphan).
+	tmp, err := os.MkdirTemp("", "network-alias-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	s := NewStore(tmp)
+
+	// Seed: two contacts for the same real person, plus a merge.
+	primary, err := s.Resolve("feishu", "ou_boss", "老板")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.Resolve("telegram", "555", "Boss (TG)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate MergeContact: record the alias on primary + delete the alias file.
+	primary.Aliases = []string{"telegram:555"}
+	primary.MsgCount += 1 // absorb alias msgCount
+	if err := s.Save(primary); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("telegram:555"); err != nil {
+		t.Fatal(err)
+	}
+	primaryBefore, _ := s.Get(primary.ID)
+	if primaryBefore == nil {
+		t.Fatal("primary missing after merge")
+	}
+	countBefore := primaryBefore.MsgCount
+
+	// Alias user sends a new message → Resolve should route to primary.
+	got, err := s.Resolve("telegram", "555", "Boss (TG)")
+	if err != nil {
+		t.Fatalf("resolve after merge: %v", err)
+	}
+	if got.ID != primary.ID {
+		t.Fatalf("expected alias to route to primary %s, got %s", primary.ID, got.ID)
+	}
+	if got.MsgCount != countBefore+1 {
+		t.Fatalf("expected primary MsgCount to increment, got %d (was %d)",
+			got.MsgCount, countBefore)
+	}
+	// Critical: no orphan alias file should be recreated.
+	orphan, err := s.Get("telegram:555")
+	if err != nil {
+		t.Fatalf("get orphan: %v", err)
+	}
+	if orphan != nil {
+		t.Fatalf("alias file should not have been recreated, got:\n%+v", orphan)
+	}
+}
+
+func TestFallbackDisplayName(t *testing.T) {
+	// Bug 2 regression: displayName fallback chain never returns empty.
+	cases := []struct {
+		name       string
+		externalID string
+		candidates []string
+		want       string
+	}{
+		{"first non-empty wins", "ou_abc", []string{"张三", "zhang3"}, "张三"},
+		{"skip empty", "ou_abc", []string{"", "", "fallback"}, "fallback"},
+		{"whitespace treated as empty", "ou_abc", []string{"  ", "real"}, "real"},
+		{"all empty → short externalID prefix", "ou_abcdefghij", []string{"", ""}, "ou_abcde"},
+		{"all empty short ID returned whole", "a1", []string{""}, "a1"},
+		{"no candidates → short prefix", "longtoken12345", nil, "longtoke"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FallbackDisplayName(tc.externalID, tc.candidates...)
+			if got != tc.want {
+				t.Fatalf("FallbackDisplayName(%q, %v) = %q, want %q",
+					tc.externalID, tc.candidates, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummaryIsOwnerSkips(t *testing.T) {
+	// Bug 1 regression: IsOwner=true → Summary() should return empty to avoid
+	// duplicating owner-profile.md injection.
+	tmp, err := os.MkdirTemp("", "network-owner-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	s := NewStore(tmp)
+	c, err := s.Resolve("feishu", "ou_owner", "老板")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.IsOwner = true
+	c.Body = "# 老板\n\n## 事实\n- 主人本人\n"
+	if err := s.Save(c); err != nil {
+		t.Fatal(err)
+	}
+	sum := s.Summary(c.ID)
+	if sum != "" {
+		t.Fatalf("IsOwner=true should produce empty summary, got:\n%s", sum)
+	}
+
+	// Sanity: after clearing IsOwner, Summary should produce content again.
+	c.IsOwner = false
+	if err := s.Save(c); err != nil {
+		t.Fatal(err)
+	}
+	sum = s.Summary(c.ID)
+	if !strings.Contains(sum, "老板") {
+		t.Fatalf("after IsOwner=false, summary should contain name:\n%s", sum)
+	}
+}
+
 func TestMigrateIfNeeded(t *testing.T) {
 	tmp, err := os.MkdirTemp("", "network-mig-*")
 	if err != nil {

--- a/pkg/network/summary.go
+++ b/pkg/network/summary.go
@@ -25,6 +25,12 @@ func (s *Store) Summary(contactID string) string {
 	if err != nil || c == nil {
 		return ""
 	}
+	// IsOwner=true 表示"这就是 agent 主人本人在该渠道的身份"。系统提示词
+	// 已经通过 memory/core/owner-profile.md 注入过主人档案，此处再注入 contact
+	// summary 会导致档案重复 + 描述冲突。直接返回空，让 owner-profile 接管。
+	if c.IsOwner {
+		return ""
+	}
 	return buildSummary(c)
 }
 

--- a/pkg/tools/network.go
+++ b/pkg/tools/network.go
@@ -69,7 +69,16 @@ func (r *Registry) handleNetworkNote(_ context.Context, input json.RawMessage) (
 		return "", fmt.Errorf("load contact: %w", err)
 	}
 	if c == nil {
-		return "", fmt.Errorf("contact %q not found (请先让用户通过该来源发过一次消息, 或手动在通讯录创建)", req.EntityID)
+		// Help the AI self-correct: suggest the 3 closest existing contact IDs
+		// by prefix/substring match so it can retry with a valid entityId.
+		suggestions := suggestContactIDs(store, req.EntityID, 3)
+		hint := ""
+		if len(suggestions) > 0 {
+			hint = " · Did you mean: " + strings.Join(suggestions, " / ") + "?"
+		} else {
+			hint = " · 当前通讯录为空或无近似匹配, 请先让用户通过该来源发过一次消息, 或手动在通讯录创建"
+		}
+		return "", fmt.Errorf("contact %q not found%s", req.EntityID, hint)
 	}
 
 	updated, err := appendToSection(c.Body, req.Section, req.Text)
@@ -92,6 +101,84 @@ func displayNameOrID(c *network.Contact) string {
 		return c.DisplayName
 	}
 	return c.ID
+}
+
+// suggestContactIDs returns up to `max` contact IDs from the store that are
+// most similar to `query`. Used by network_note to help the AI self-correct
+// a typo'd entityId.
+//
+// Ranking:
+//  1. Exact source prefix match (e.g. "feishu:xxx" gets other feishu: entries first)
+//  2. Substring match in full ID
+//  3. Fuzzy score (simple char overlap)
+//
+// Keep it dependency-free; this runs on every failed note call so must be cheap.
+func suggestContactIDs(store *network.Store, query string, maxN int) []string {
+	list, err := store.List()
+	if err != nil || len(list) == 0 {
+		return nil
+	}
+	q := strings.ToLower(query)
+	// Extract source prefix if present ("feishu:xxx" → "feishu")
+	qSource := ""
+	if i := strings.Index(q, ":"); i > 0 {
+		qSource = q[:i]
+	}
+
+	ranked := make([]scoredID, 0, len(list))
+	for _, c := range list {
+		id := c.ID
+		idLower := strings.ToLower(id)
+		score := 0
+		// Prefix-of-source match
+		if qSource != "" && strings.HasPrefix(idLower, qSource+":") {
+			score += 100
+		}
+		// Substring
+		if strings.Contains(idLower, q) || strings.Contains(q, idLower) {
+			score += 50
+		}
+		// Name substring (AI might give a display name by mistake)
+		if c.DisplayName != "" && strings.Contains(strings.ToLower(c.DisplayName), q) {
+			score += 40
+		}
+		// Character overlap (rough fuzz)
+		overlap := 0
+		qSet := map[rune]bool{}
+		for _, r := range q {
+			qSet[r] = true
+		}
+		for _, r := range idLower {
+			if qSet[r] {
+				overlap++
+			}
+		}
+		score += overlap
+		ranked = append(ranked, scoredID{id: id, score: score})
+	}
+	sortSuggestions(ranked)
+	out := make([]string, 0, maxN)
+	for i := 0; i < len(ranked) && i < maxN; i++ {
+		if ranked[i].score > 0 {
+			out = append(out, ranked[i].id)
+		}
+	}
+	return out
+}
+
+type scoredID struct {
+	id    string
+	score int
+}
+
+// sortSuggestions sorts scored entries descending by score (stable).
+func sortSuggestions(xs []scoredID) {
+	// insertion sort — list is small (typically <30 contacts per agent)
+	for i := 1; i < len(xs); i++ {
+		for j := i; j > 0 && xs[j].score > xs[j-1].score; j-- {
+			xs[j], xs[j-1] = xs[j-1], xs[j]
+		}
+	}
 }
 
 // appendToSection takes a contact body (markdown) and appends `- <text>` at the

--- a/pkg/tools/network_suggest_test.go
+++ b/pkg/tools/network_suggest_test.go
@@ -1,0 +1,50 @@
+package tools
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Zyling-ai/zyhive/pkg/network"
+)
+
+func TestSuggestContactIDs(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "suggest-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	store := network.NewStore(tmp)
+	if _, err := store.Resolve("feishu", "ou_abc", "张三"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Resolve("feishu", "ou_xyz", "李四"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Resolve("telegram", "12345", "Boss"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Typo: AI mangled the ID. Should suggest feishu ones first due to source prefix.
+	sugg := suggestContactIDs(store, "feishu:ou_", 3)
+	if len(sugg) == 0 {
+		t.Fatalf("expected suggestions, got none")
+	}
+	if !strings.HasPrefix(sugg[0], "feishu:") {
+		t.Fatalf("top suggestion should be feishu: got %q", sugg[0])
+	}
+
+	// Unrelated query — still returns top matches (non-empty if store has any).
+	sugg = suggestContactIDs(store, "zzz_nothing_matches", 3)
+	// Allowed to be empty if score 0 across the board, just shouldn't panic.
+	_ = sugg
+
+	// Empty store → nil
+	tmp2, _ := os.MkdirTemp("", "suggest-empty-*")
+	defer os.RemoveAll(tmp2)
+	empty := network.NewStore(tmp2)
+	if got := suggestContactIDs(empty, "anything", 3); got != nil {
+		t.Fatalf("empty store should return nil, got %v", got)
+	}
+}

--- a/pkg/tools/relations_helper.go
+++ b/pkg/tools/relations_helper.go
@@ -41,8 +41,22 @@ func allowedPeersFromRelations(workspaceDir string) map[string]bool {
 			continue
 		}
 		id := cols[0]
-		if id == "" || strings.HasPrefix(id, "-") || strings.Contains(id, "成员") || strings.EqualFold(id, "ID") {
+		if id == "" || strings.HasPrefix(id, "-") ||
+			strings.Contains(id, "成员") || strings.Contains(id, "目标") ||
+			strings.EqualFold(id, "ID") {
 			continue
+		}
+		// Contact IDs contain ":" (e.g. "feishu:ou_abc") — skip, only agents
+		// are dispatchable.
+		if strings.Contains(id, ":") {
+			continue
+		}
+		// New 6-col format has toKind in col[2]; skip non-agent rows.
+		if len(cols) >= 6 {
+			kind := strings.ToLower(cols[2])
+			if kind != "" && kind != "agent" {
+				continue
+			}
 		}
 		peers[id] = true
 	}


### PR DESCRIPTION
26.4.22v1 通讯录 GA 后, 自审 + 讨论发现 5 个已发布代码漏洞.
本次一次性清理, 不新增功能.

### Bug 1: IsOwner=true 的 contact 没阻断 summary 注入

现象: 用户在 TeamView 抽屉勾 '这是主人本人在该渠道的身份',
期望 AI 用 owner-profile.md 而非注入 contact summary, 但代码 无脑调 Store.Summary() → 双份档案、描述冲突.

修: pkg/network/summary.go Summary() 检查 c.IsOwner, true 则 返回空串. 调用方无需改动.

### Bug 2: displayName fallback 链缺失

现象: 飞书 getSenderName() 可能返回 '' (刚加好友 / 群聊成员
未拉取); TG FirstName+Username 都可能空. 落盘后 UI 显示空白.

修: pkg/network/store.go 新增 FallbackDisplayName() 统一兜底 链 (candidate → candidate → externalID[:8]). 3 处入口 (TG / 飞书 / Web Public) 统一用它.

### Bug 3: 合并后 alias 来消息会'复活'

现象: 合并 telegram:123 → feishu:ou_boss 后 alias 文件删除, TG 用户再发消息 → Resolve 查不到 → 新建空档案, 合并白做.

修: pkg/network/store.go Resolve() 没直接命中时扫描所有
primary 档案的 Aliases 字段; 新增 findPrimaryByAliasUnlocked() helper. 命中则 Touch primary 而不是新建.

### Bug 4: Graph / 派遣检查 含 contact 行时行为异常

现象: 26.4.22v1 CHANGELOG 说 '关系表扩展 toKind', 实际代码
仍只读 5 列. 如果手工或 AI 写入 contact 关系行, Graph 会创
建幽灵 agent 节点; allowedPeersFromRelations 会把 contact ID 当可派遣对象.

修:
* internal/api/relations.go RelationRow 正式加 ToKind 字段
* parseRelationsMarkdown 支持 6 列新格式 + 5 列 legacy 回退
* writeRelationsFile 输出 6 列
* validTypes 扩充: 服务/客户/家人/朋友/同事/合作伙伴
* Graph handler 跳过 ToKind != 'agent' 的边 (联系人在单独 tab)
* pkg/tools/relations_helper.go allowedPeersFromRelations 过滤 带冒号的 ID 和 6 列格式中 kind != agent 的行

### 瑕疵 5: network_note 找不到 entity 时错误不友好

现象: AI 传了乱编 entityId → 只返回 'not found', AI 无法
自我纠正.

修: pkg/tools/network.go 新增 suggestContactIDs() 基于源前缀 / 子串 / 字符重叠打分, 返回 top 3 近似 ID 作为 'Did you mean:'
提示. 失败时 error 带上候选.

### 测试

* pkg/network/store_test.go 新增:
  - TestSummaryIsOwnerSkips (Bug 1)
  - TestFallbackDisplayName (Bug 2, 6 子 case)
  - TestResolveRoutesThroughAliases (Bug 3)
* internal/api/relations_test.go 新增:
  - TestParseRelationsMarkdown6ColNewFormat (Bug 4)
  - TestParseRelationsMarkdown5ColLegacy (legacy 兼容)
  - TestWriteRelationsFileRoundTrip (6 列往返)
* pkg/tools/network_suggest_test.go 新增:
  - TestSuggestContactIDs (瑕疵 5)

全栈测试:
  go test ./pkg/network/... ./pkg/tools/... ./internal/api/...  ✅