### PR TITLE
fix: validate unpublished drafts by ID and SHA

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -8,6 +8,14 @@ on:
         description: Existing draft release tag to validate and publish
         required: true
         type: string
+      candidate_sha:
+        description: Exact main commit used to build the draft assets
+        required: true
+        type: string
+      release_id:
+        description: Database ID of the existing private draft release
+        required: true
+        type: string
       previous_version:
         description: Previous stable release used by update tests
         required: false
@@ -33,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ inputs.candidate_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -41,11 +49,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          RELEASE_ID: ${{ inputs.release_id }}
           REPOSITORY: ${{ github.repository }}
         run: |
           test "$GITHUB_REF" = "refs/heads/main"
-          test "$(gh api "repos/${REPOSITORY}/releases/tags/${VERSION}" --jq '.draft')" = "true"
-          test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$VERSION")"
+          release="$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}")"
+          test "$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)[\"draft\"]).lower())' <<<"$release")" = "true"
+          test "$(python3 -c 'import json,sys; print(json.load(sys.stdin)[\"tag_name\"])' <<<"$release")" = "$VERSION"
+          test "$(python3 -c 'import json,sys; print(json.load(sys.stdin)[\"target_commitish\"])' <<<"$release")" = "$CANDIDATE_SHA"
+          test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
           git merge-base --is-ancestor HEAD origin/main
           scripts/verify-commit-identity.sh
 
@@ -214,7 +227,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ inputs.candidate_sha }}
 
       - uses: actions/setup-go@v5
         with:
@@ -263,13 +276,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          RELEASE_ID: ${{ inputs.release_id }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          release="$(gh api "repos/${REPOSITORY}/releases/tags/${VERSION}")"
+          release="$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}")"
           test "$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)[\"draft\"]).lower())' <<<"$release")" = "true"
-          target="$(git ls-remote "https://github.com/${REPOSITORY}.git" "refs/tags/${VERSION}" | awk '{print $1}')"
-          test -n "$target"
-          test "$target" = "$(gh api "repos/${REPOSITORY}/git/ref/tags/${VERSION}" --jq '.object.sha')"
+          test "$(python3 -c 'import json,sys; print(json.load(sys.stdin)[\"tag_name\"])' <<<"$release")" = "$VERSION"
+          target="$(python3 -c 'import json,sys; print(json.load(sys.stdin)[\"target_commitish\"])' <<<"$release")"
+          test "$target" = "$CANDIDATE_SHA"
 
       - name: Publish verified candidate
         env:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -178,6 +178,10 @@ gh release create "$VERSION" \
   --title "$VERSION" \
   --notes "$release_notes" \
   --draft
+candidate_sha="$(git rev-parse HEAD)"
+release_id="$(
+  gh release view "$VERSION" --repo "$REPO" --json databaseId --jq '.databaseId'
+)"
 
 echo "☁️  [8/9] 触发四平台候选验证、供应链签名与唯一发布门..."
 previous_run_id="$(
@@ -195,6 +199,8 @@ gh workflow run release-e2e.yml \
   --repo "$REPO" \
   --ref main \
   -f "version=$VERSION" \
+  -f "candidate_sha=$candidate_sha" \
+  -f "release_id=$release_id" \
   -f "previous_version=$PREVIOUS_VERSION"
 
 run_id=""

--- a/scripts/test/release_draft_gate_test.py
+++ b/scripts/test/release_draft_gate_test.py
@@ -16,6 +16,8 @@ def require(condition: bool, message: str) -> None:
 
 require("workflow_dispatch:" in WORKFLOW, "release gate must be explicitly dispatched")
 require("types: [published]" not in WORKFLOW, "validation must not start after publication")
+require("ref: ${{ inputs.candidate_sha }}" in WORKFLOW, "draft candidates must be checked out by immutable commit")
+require("releases/${RELEASE_ID}" in WORKFLOW, "draft verification must use its database ID before a tag exists")
 require("candidate-install-update:" in WORKFLOW, "candidate install/update gate is missing")
 require("needs: [supply-chain, candidate-install-update]" in WORKFLOW, "promotion must depend on every candidate gate")
 require("run: gh release edit \"$VERSION\" --repo \"$REPOSITORY\" --draft=false --latest" in WORKFLOW,
@@ -28,6 +30,8 @@ draft_at = SCRIPT.index("--draft")
 dispatch_at = SCRIPT.index("gh workflow run release-e2e.yml")
 require(draft_at < dispatch_at, "draft must exist before candidate validation starts")
 require("gh release create \"$VERSION\"" in SCRIPT, "release script must create the candidate")
+require("-f \"candidate_sha=$candidate_sha\"" in SCRIPT, "dispatch must bind the candidate commit")
+require("-f \"release_id=$release_id\"" in SCRIPT, "dispatch must bind the private draft identity")
 require("gh release edit \"$VERSION\" --repo \"$REPO\" --draft" not in SCRIPT,
         "local script must never publish or withdraw around failed validation")
 require("gh run watch \"$run_id\"" in SCRIPT, "release script must wait for the promotion workflow")


### PR DESCRIPTION
## Summary
- check out private candidates by immutable main commit instead of a tag that does not exist yet
- bind validation to the Draft Release database ID, expected tag name and target SHA
- keep the only public tag creation in the final promotion step

## Test plan
- [x] first private candidate correctly stayed Draft on failure
- [x] Draft assets downloadable through authenticated `gh release download`
- [x] workflow YAML parse and state-machine contract tests
- [ ] required GitHub checks

Made with [Cursor](https://cursor.com)