### PR TITLE
fix: read private draft fields safely

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -54,10 +54,9 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           test "$GITHUB_REF" = "refs/heads/main"
-          release="$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}")"
-          test "$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)[\"draft\"]).lower())' <<<"$release")" = "true"
-          test "$(python3 -c 'import json,sys; print(json.load(sys.stdin)[\"tag_name\"])' <<<"$release")" = "$VERSION"
-          test "$(python3 -c 'import json,sys; print(json.load(sys.stdin)[\"target_commitish\"])' <<<"$release")" = "$CANDIDATE_SHA"
+          test "$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}" --jq '.draft')" = "true"
+          test "$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}" --jq '.tag_name')" = "$VERSION"
+          test "$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}" --jq '.target_commitish')" = "$CANDIDATE_SHA"
           test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
           git merge-base --is-ancestor HEAD origin/main
           scripts/verify-commit-identity.sh
@@ -280,10 +279,9 @@ jobs:
           RELEASE_ID: ${{ inputs.release_id }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          release="$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}")"
-          test "$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)[\"draft\"]).lower())' <<<"$release")" = "true"
-          test "$(python3 -c 'import json,sys; print(json.load(sys.stdin)[\"tag_name\"])' <<<"$release")" = "$VERSION"
-          target="$(python3 -c 'import json,sys; print(json.load(sys.stdin)[\"target_commitish\"])' <<<"$release")"
+          test "$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}" --jq '.draft')" = "true"
+          test "$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}" --jq '.tag_name')" = "$VERSION"
+          target="$(gh api "repos/${REPOSITORY}/releases/${RELEASE_ID}" --jq '.target_commitish')"
           test "$target" = "$CANDIDATE_SHA"
 
       - name: Publish verified candidate

--- a/scripts/test/release_draft_gate_test.py
+++ b/scripts/test/release_draft_gate_test.py
@@ -18,6 +18,7 @@ require("workflow_dispatch:" in WORKFLOW, "release gate must be explicitly dispa
 require("types: [published]" not in WORKFLOW, "validation must not start after publication")
 require("ref: ${{ inputs.candidate_sha }}" in WORKFLOW, "draft candidates must be checked out by immutable commit")
 require("releases/${RELEASE_ID}" in WORKFLOW, "draft verification must use its database ID before a tag exists")
+require("--jq '.draft'" in WORKFLOW, "draft state must be read without shell-escaped inline Python")
 require("candidate-install-update:" in WORKFLOW, "candidate install/update gate is missing")
 require("needs: [supply-chain, candidate-install-update]" in WORKFLOW, "promotion must depend on every candidate gate")
 require("run: gh release edit \"$VERSION\" --repo \"$REPOSITORY\" --draft=false --latest" in WORKFLOW,


### PR DESCRIPTION
## Summary
- replace shell-escaped inline Python with direct `gh api --jq` field reads
- verify the exact private Draft metadata locally
- retain ID, tag name and immutable SHA checks

## Test plan
- [x] local assertions against Draft Release 363607324
- [x] static release state-machine contract
- [x] Bash syntax
- [ ] required GitHub checks

Made with [Cursor](https://cursor.com)