### PR TITLE
fix: stage private candidates for native runners

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -201,6 +201,20 @@ jobs:
             gh attestation verify "verified/$file" --repo "$REPOSITORY"
           done
 
+      - name: Stage verified candidate for native runners
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-candidate-${{ inputs.version }}
+          path: |
+            dist/zyhive-linux-amd64
+            dist/zyhive-linux-arm64
+            dist/zyhive-darwin-amd64
+            dist/zyhive-darwin-arm64
+            dist/install.sh
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 1
+
   candidate-install-update:
     name: Candidate install/update (${{ matrix.name }})
     needs: supply-chain
@@ -233,16 +247,19 @@ jobs:
           go-version: '1.25.10'
           cache: true
 
-      - name: Download exact draft candidate
+      - name: Download verified candidate artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-candidate-${{ inputs.version }}
+          path: dist
+
+      - name: Prepare exact candidate and previous stable binary
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
           PREVIOUS_VERSION: ${{ inputs.previous_version }}
           BINARY: zyhive-${{ matrix.name }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          mkdir dist
-          gh release download "$VERSION" --repo "$REPOSITORY" --dir dist
           bash scripts/release-supply-chain.sh verify-checksums dist
           if [[ -n "$PREVIOUS_VERSION" ]]; then
             mkdir previous

--- a/scripts/test/release_draft_gate_test.py
+++ b/scripts/test/release_draft_gate_test.py
@@ -19,6 +19,8 @@ require("types: [published]" not in WORKFLOW, "validation must not start after p
 require("ref: ${{ inputs.candidate_sha }}" in WORKFLOW, "draft candidates must be checked out by immutable commit")
 require("releases/${RELEASE_ID}" in WORKFLOW, "draft verification must use its database ID before a tag exists")
 require("--jq '.draft'" in WORKFLOW, "draft state must be read without shell-escaped inline Python")
+require("uses: actions/upload-artifact@v4" in WORKFLOW, "verified draft assets must be staged for read-only runners")
+require("uses: actions/download-artifact@v4" in WORKFLOW, "native runners must consume the verified artifact")
 require("candidate-install-update:" in WORKFLOW, "candidate install/update gate is missing")
 require("needs: [supply-chain, candidate-install-update]" in WORKFLOW, "promotion must depend on every candidate gate")
 require("run: gh release edit \"$VERSION\" --repo \"$REPOSITORY\" --draft=false --latest" in WORKFLOW,


### PR DESCRIPTION
## Summary
- upload only supply-chain-verified core assets as a one-day Actions artifact
- let four native candidate jobs download that artifact without Release write access
- keep previous stable assets on normal read-only Release access

## Test plan
- [x] supply-chain job passed for the current private candidate
- [x] all four native labels started and reproduced the expected Draft visibility limitation
- [x] workflow YAML and release state-machine contracts pass
- [ ] required GitHub checks

Made with [Cursor](https://cursor.com)