### PR TITLE
fix: restore candidate executable modes

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -260,6 +260,7 @@ jobs:
           BINARY: zyhive-${{ matrix.name }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          chmod +x dist/zyhive-* dist/install.sh
           bash scripts/release-supply-chain.sh verify-checksums dist
           if [[ -n "$PREVIOUS_VERSION" ]]; then
             mkdir previous

--- a/scripts/test/release_draft_gate_test.py
+++ b/scripts/test/release_draft_gate_test.py
@@ -21,6 +21,7 @@ require("releases/${RELEASE_ID}" in WORKFLOW, "draft verification must use its d
 require("--jq '.draft'" in WORKFLOW, "draft state must be read without shell-escaped inline Python")
 require("uses: actions/upload-artifact@v4" in WORKFLOW, "verified draft assets must be staged for read-only runners")
 require("uses: actions/download-artifact@v4" in WORKFLOW, "native runners must consume the verified artifact")
+require("chmod +x dist/zyhive-* dist/install.sh" in WORKFLOW, "artifact mode loss must be repaired before execution")
 require("candidate-install-update:" in WORKFLOW, "candidate install/update gate is missing")
 require("needs: [supply-chain, candidate-install-update]" in WORKFLOW, "promotion must depend on every candidate gate")
 require("run: gh release edit \"$VERSION\" --repo \"$REPOSITORY\" --draft=false --latest" in WORKFLOW,


### PR DESCRIPTION
## Summary
- restore executable bits lost during Actions artifact transfer
- keep checksum verification after mode restoration
- lock the behavior with the release contract test

## Test plan
- [x] downloaded the exact candidate artifact from the failed run
- [x] simulated mode loss and restoration locally
- [x] checksum and 26.8.2v1 execution passed after restoration
- [ ] required GitHub checks

Made with [Cursor](https://cursor.com)