### PR TITLE
fix: tolerate cold Release fixture startup

### DIFF
--- a/scripts/test/release-e2e/run.sh
+++ b/scripts/test/release-e2e/run.sh
@@ -318,14 +318,23 @@ set_fixture_latest() {
 start_fixture_server() {
   local fixture_root="$1"
   local port_file="$TMP_ROOT/fixture-port"
+  local attempts="${ZYHIVE_FIXTURE_START_ATTEMPTS:-300}"
+  [[ "$attempts" =~ ^[0-9]+$ ]] || attempts=300
   python3 "$SERVER_SCRIPT" "$fixture_root" "$port_file" >"$TMP_ROOT/fixture-server.log" 2>&1 &
   local pid=$!
   PIDS+=("$pid")
-  for _ in $(seq 1 50); do
+  for _ in $(seq 1 "$attempts"); do
     [[ -s "$port_file" ]] && break
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
     sleep 0.1
   done
-  [[ -s "$port_file" ]] || fail "本地 Release 服务启动失败"
+  if [[ ! -s "$port_file" ]]; then
+    echo "本地 Release 服务日志：" >&2
+    [[ -f "$TMP_ROOT/fixture-server.log" ]] && while IFS= read -r line; do echo "$line" >&2; done <"$TMP_ROOT/fixture-server.log"
+    fail "本地 Release 服务启动失败"
+  fi
   FIXTURE_BASE="http://127.0.0.1:$(<"$port_file")"
 }
 


### PR DESCRIPTION
## Summary
- increase the bounded fixture startup window from 5 to 30 seconds
- stop waiting immediately if the Python server exits
- print server diagnostics on failure without weakening journey assertions

## Test plan
- [x] supply chain and Linux amd64/arm64 plus macOS arm64 passed
- [x] exact 26.8.1v14 → 26.8.2v1 full journey passed locally
- [x] Bash syntax
- [ ] required GitHub checks

Made with [Cursor](https://cursor.com)