### PR TITLE
fix: pin candidate and journey harness separately

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -240,7 +240,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.candidate_sha }}
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-go@v5
         with:

--- a/scripts/test/release_draft_gate_test.py
+++ b/scripts/test/release_draft_gate_test.py
@@ -16,7 +16,10 @@ def require(condition: bool, message: str) -> None:
 
 require("workflow_dispatch:" in WORKFLOW, "release gate must be explicitly dispatched")
 require("types: [published]" not in WORKFLOW, "validation must not start after publication")
-require("ref: ${{ inputs.candidate_sha }}" in WORKFLOW, "draft candidates must be checked out by immutable commit")
+require(WORKFLOW.count("ref: ${{ inputs.candidate_sha }}") == 1,
+        "only reproducible supply-chain rebuilds may check out the candidate source")
+require(WORKFLOW.count("ref: ${{ github.sha }}") == 1,
+        "native journeys must use the immutable reviewed harness commit")
 require("releases/${RELEASE_ID}" in WORKFLOW, "draft verification must use its database ID before a tag exists")
 require("--jq '.draft'" in WORKFLOW, "draft state must be read without shell-escaped inline Python")
 require("uses: actions/upload-artifact@v4" in WORKFLOW, "verified draft assets must be staged for read-only runners")


### PR DESCRIPTION
## Summary
- keep supply-chain rebuilds on the original candidate SHA
- run native journeys from the immutable reviewed workflow SHA
- prevent a private candidate from freezing an older buggy test harness

## Test plan
- [x] candidate SHA still uniquely controls reproducible assets
- [x] workflow SHA uniquely controls native journey scripts
- [x] three native platforms already pass the exact candidate
- [x] exact v14 → v1 journey passes locally with the reviewed harness
- [ ] required GitHub checks

Made with [Cursor](https://cursor.com)